### PR TITLE
reconnect websockets ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ See the examples in the `examples` folder.
 
 # Development
 Our [TUIO 1.1 Simulator fork](https://github.com/paul-peters/TUIO11_Simulator) contains an [executable jar](https://github.com/paul-peters/TUIO11_Simulator/tree/master/release/TUIO_Simulator_WS) to simulate a tuio websocket on `localhost`.
+
+We are also working on a TUIO2.0 simulator. If you like to have a look at a preview contact us at github@interactive-scape.com

--- a/examples/tuio20.html
+++ b/examples/tuio20.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'>
+    <title>TUIO 2.0 client js example</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <script src="../src/libs/osc-browser.js"></script>
+    <style>
+        #text {
+            position: fixed; 
+            bottom: 0px; 
+            overflow: auto; 
+            max-height: calc(100vh - 80px); 
+            max-width: calc(100vw - 40px); 
+            margin: 40px 20px
+        }
+
+        #playPauseButton {
+            width: 5em
+        }
+    </style>
+</head>
+<body>
+    <div id="text"></div>
+    <div style="position: fixed; right: 20px">
+        <button id="playPauseButton" >Pause</button>
+        <button id="clearButton">Clear</button>    
+    </div>
+
+    <script type="module">
+        import {Tuio20Client} from "../src/tuio20/Tuio20Client.js";
+        import {Tuio20Listener} from "../src/tuio20/Tuio20Listener.js";
+        import {WebsocketTuioReceiver} from "../src/common/WebsocketTuioReceiver.js";
+
+        const WEBSOCKET_URL = "ws://localhost:3343/"
+
+        let textElement = document.getElementById("text")
+        let playPauseButtonElement = document.getElementById("playPauseButton")
+        let clearButtonElement = document.getElementById("clearButton")
+
+        let paused = false
+        playPauseButtonElement.onclick = function() {
+            if (playPauseButtonElement.textContent == "Pause")  {
+                paused = true
+                playPauseButtonElement.textContent = "Go"
+            } else {
+                paused = false
+                playPauseButtonElement.textContent = "Pause"
+            }
+        }
+        clearButtonElement.onclick = function() {
+            textElement.innerHTML = ""
+        }
+        function writeEvent(eventName, tuioObject) {
+            if (paused) return
+            console.log(eventName, ": ", tuioObject)
+            let jsonString = JSON.stringify(tuioObject, (key, value) => {
+                if (key == "_container") {
+                    return "tuioObject_backref";
+                }
+                if (key == "_prevPoints") {
+                    return "previous_points_omitted";
+                }
+                return value;
+            })
+            textElement.innerHTML = eventName + ": " + jsonString + "</br>" + text.innerHTML
+        }
+        class DebugTuio20Listener extends Tuio20Listener {
+            tuioAdd(tuioObject){
+                writeEvent("tuioAdd", tuioObject)
+            }
+
+            tuioUpdate(tuioObject){
+                writeEvent("tuioUpdate", tuioObject)
+            }
+
+            tuioRemove(tuioObject){
+                writeEvent("tuioRemove", tuioObject)
+            }
+
+            tuioRefresh(time){
+                writeEvent("tuioRefresh", time)
+            }
+        }
+
+        const client = new Tuio20Client(new WebsocketTuioReceiver(WEBSOCKET_URL))
+
+        client.addTuioListener(new DebugTuio20Listener())
+        client.connect()
+    </script>
+</body>
+</html>

--- a/src/common/TuioReceiver.js
+++ b/src/common/TuioReceiver.js
@@ -1,6 +1,5 @@
 export class TuioReceiver {
     constructor() {
-        this._isConnected = false;
         this._messageListeners = {};
     }
 

--- a/src/common/WebsocketTuioReceiver.js
+++ b/src/common/WebsocketTuioReceiver.js
@@ -28,7 +28,6 @@ export class WebsocketTuioReceiver extends TuioReceiver {
             this.onOscMessage(oscMessage);
         }.bind(this));
         this._oscPort.on("close", function(error) {
-            console.log("closed:", this, "message:", error)
             this.connect()
         }.bind(this));
     }

--- a/src/common/WebsocketTuioReceiver.js
+++ b/src/common/WebsocketTuioReceiver.js
@@ -1,25 +1,44 @@
 import {TuioReceiver} from "./TuioReceiver.js";
 
 export class WebsocketTuioReceiver extends TuioReceiver {
-    constructor(url) {
+    constructor(url, reconnect=true) {
         super();
-        this._oscPort = new osc.WebSocketPort({
-            url: url,
-            metadata: true
-        });
+        this._url = url
+        this._reconnect = reconnect;
     }
 
     connect(){
+        if (this.isConnected()) {
+            return;
+        }
+        if (this._oscPort && this._oscPort.socket && this._oscPort.socket.readyState === 0) {
+            this.disconnect()
+            window.setTimeout(this.connect.bind(this), 1000)
+            return;
+        }
+        this._oscPort = new osc.WebSocketPort({
+            url: this._url,
+            metadata: true
+        });
         this._oscPort.open();
-        this._isConnected = true;
+        if (this._reconnect && ! this.isConnected()) {
+            window.setTimeout(this.connect.bind(this), 5000)
+        }
         this._oscPort.on("message", function(oscMessage) {
             this.onOscMessage(oscMessage);
+        }.bind(this));
+        this._oscPort.on("close", function(error) {
+            console.log("closed:", this, "message:", error)
+            this.connect()
         }.bind(this));
     }
 
     disconnect(){
-        this._oscPort.close();
-        this._isConnected = false;
+        if (this._oscPort) this._oscPort.close();
+    }
+
+    isConnected() {
+        return this._oscPort && this._oscPort.socket && this._oscPort.socket.readyState === 1
     }
 }
 


### PR DESCRIPTION
# Feature
The  `WebsocketTuioReceiver` should try to reconnect automatically if the server closed the websocket or if the connection fails at init.

# Solution
Introduce a flag which controls the reconnection behavior, which is `true` by default. If the `reconnect` flag is  `true` enter into a connection loop until the sockets ready state equals 1 at init or when the connection was close.

# Testing
Check that the TUIO 1.1 example does not stop working when the TUIO 1.1 web socket server (e.g. from the simulator) was stopped and restarted.